### PR TITLE
Try to switch to virt-install

### DIFF
--- a/cbox.in
+++ b/cbox.in
@@ -95,10 +95,9 @@ function print_usage() {
 	echo " -O osname                      use kickstart without fedora prefix distributed with cbox. This overrides -r"
 	echo " -q                             enable qdiskd for cman clusters (default: no)"
 	echo " -r fedora_release              force fedora release to install on the nodes (defaults: autodetect/same as host)"
-	echo " -t [cman|corosync]             define cluster type (default: cman)"
+	echo " -t [cman|corosync|ceph]        define cluster type (default: cman)"
 	echo " -u repo_URL                    use additional custom yum repository"
 	echo " -h                             this help"
-	echo " -C                             enable appliance-creator cache (stored in /srv/cbox/accache)"
 	echo " -E regexp                      exclude given script (regexp is matched by =~ bash operator)"
 	echo " -D                             enable creation of driver node"
 	echo " -v virt_opts                   define virtual nodes and storage size in a comma separated list of parameters"
@@ -196,7 +195,7 @@ function parse_virt_opts() {
 # o -> output dir (cboxvmsdir)
 # q -> enable qdiskd (cboxqdiskd)
 # r -> fedora release (13 / 14 / rawhide)
-# t -> type (cboxclustertype) cman|corosync
+# t -> type (cboxclustertype) cman|corosync|ceph
 # v -> virt params (ram/cpu/root/swap)
 # l -> disable guestmount and use loop and kpartx
 
@@ -224,13 +223,10 @@ cboxvirtroot=4096
 cboxvirtswap=$((cboxvirtram / 2))
 cboxvirtshare=20544
 
-while getopts ":c:dfhk:lm:n:o:O:qr:t:u:v:CE:D" optflag; do
+while getopts ":c:dfhk:lm:n:o:O:qr:t:u:v:E:D" optflag; do
 	case "$optflag" in
 	c)
 		cboxclustername="$OPTARG"
-		;;
-	C)
-		cboxcache="yes"
 		;;
 	d)
 		cboxdevel="yes"
@@ -281,8 +277,9 @@ while getopts ":c:dfhk:lm:n:o:O:qr:t:u:v:CE:D" optflag; do
 	t)
 		cboxclustertype="$OPTARG"
 		if [ "$cboxclustertype" != "cman" ] && \
-		   [ "$cboxclustertype" != "corosync" ]; then
-			echo "ERROR: cluster type has to be cman or corosync"
+		   [ "$cboxclustertype" != "corosync" ] && \
+		   [ "$cboxclustertype" != "ceph" ]; then
+			echo "ERROR: cluster type has to be cman, corosync or ceph"
 			exit 1
 		fi
 		;;
@@ -394,10 +391,10 @@ if [ -z "$cboxfedrelease" ]; then
 	fi
 fi
 
-[ -z "$cboxclustertype" ] && cboxclustertype=cman
-[ "$cboxfedrelease" != "rawhide" ] && [ "$cboxfedrelease" != "custom" ] && \
-	[ "$cboxfedrelease" -gt 16 ] && cboxclustertype=corosync
-[ "$cboxfedrelease" = "rawhide" ] && cboxclustertype=corosync
+[ -z "$cboxclustertype" ] && cboxclustertype=corosync
+#[ "$cboxfedrelease" != "rawhide" ] && [ "$cboxfedrelease" != "custom" ] && \
+#	[ "$cboxfedrelease" -gt 16 ] && cboxclustertype=corosync
+#[ "$cboxfedrelease" = "rawhide" ] && cboxclustertype=corosync
 
 [ -z "$cboxrasmngr" ] && cboxrasmngr=none
 
@@ -498,7 +495,6 @@ export cboxvirtshare
 export cboxuseloop
 export cboxemulator
 export cboxrepourl
-export cboxcache
 export cboxdrivernode
 
 echo ""

--- a/cbox.in
+++ b/cbox.in
@@ -172,7 +172,7 @@ function parse_virt_opts() {
 				echo "ERROR: virt shared disk size needs to be an integer"
 				exit 1
 			}
-			[ "$cboxvirtshare" -lt "20544" ] && {
+			[ "$cboxclustertype" != "ceph" -a "$cboxvirtshare" -lt "20544" ] && {
 				echo "ERROR: virt shared disk size needs to be a reasonable value (hint: greater than 20544 MB)"
 				exit 1
 			}

--- a/configure.ac
+++ b/configure.ac
@@ -48,9 +48,9 @@ AC_PROG_LN_S
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
 
-AC_CHECK_PROGS([APPCREATOR],[appliance-creator])
-if test -z "$APPCREATOR"; then
-	AC_MSG_ERROR([you don't seem to have appliance-creator; it is required])
+AC_CHECK_PROGS([VIRTINSTALL],[virt-install])
+if test -z "$VIRTINSTALL"; then
+	AC_MSG_ERROR([you don't seem to have virt-install; it is required])
 fi
 
 AC_PATH_TOOL([CBOXEMULATOR],[qemu-kvm],,[/usr/bin:/usr/libexec])

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -7,6 +7,7 @@ KICKSTARTS		= fedora-13.ks \
 			  fedora-17.ks \
 			  fedora-18.ks \
 			  fedora-21.ks \
+			  fedora-22.ks \
 			  fedora-rawhide.ks \
 			  packages_cman.ks \
 			  packages_corosync.ks \

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -6,7 +6,11 @@ KICKSTARTS		= fedora-13.ks \
 			  fedora-16.ks \
 			  fedora-17.ks \
 			  fedora-18.ks \
-			  fedora-rawhide.ks
+			  fedora-21.ks \
+			  fedora-rawhide.ks \
+			  packages_cman.ks \
+			  packages_corosync.ks \
+			  packages_ceph.ks
 
 TEMPLATES		= libvirt_template.xml
 

--- a/data/fedora-21.ks
+++ b/data/fedora-21.ks
@@ -25,18 +25,16 @@ part biosboot --fstype=biosboot --size=1 --ondisk=vda
 part / --fstype ext4 --size=@ROOTSIZE@ --ondisk=vda
 part swap --size=@SWAPSIZE@ --fstype swap --ondisk=vda
 
-part /srv/cbox/qdiskd --size=@QDISKDSIZE@   --fstype=ext4 --ondisk=vdb
-part /srv/cbox/gfs2   --size=@GFS2SIZE@ --fstype=ext4 --ondisk=vdb
-part /srv/cbox/clvmd  --size=@CLVMDSIZE@ --fstype=ext4 --ondisk=vdb
+# /dev/vdb is partitioned in scripts acording to cluster type
 
 #
 # Repositories
 #
 # This will be parsed for virt-install to download image
-#IMAGE_TREE=http://ftp.linux.cz/pub/linux/fedora/linux/releases/21/Server/x86_64/os/
-#           http://download.eng.brq.redhat.com/pub/fedora/linux/development/rawhide/x86_64/os/
+#IMAGE_TREE=http://download.fedoraproject.org/pub/fedora/linux/releases/21/Server/x86_64/os/
 
-repo --name=rawhide --mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=rawhide&arch=x86_64
+repo --name="Fedora" --mirrorlist="http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-21&arch=x86_64"
+repo --name="FedoraUpdates" --mirrorlist="http://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f21&arch=x86_64"
 @REPOURL@
 
 #

--- a/data/fedora-22.ks
+++ b/data/fedora-22.ks
@@ -1,0 +1,56 @@
+install
+text
+lang C
+keyboard us
+timezone --utc @TIMEZONE@
+auth --useshadow --enablemd5
+selinux --permissive
+firewall --disabled
+bootloader --location=mbr --driveorder vda,vdb --timeout=1
+network --bootproto=dhcp --device=eth0 --onboot=on
+network --bootproto=dhcp --device=eth1 --onboot=on
+services --enabled=network
+rootpw cluster
+poweroff
+
+#
+# Disk configuration
+#
+
+bootloader --location=mbr --append="console=tty0 console=ttyS0,115200"
+zerombr
+clearpart --all --drives=vda,vdb --initlabel --disklabel=gpt
+
+part biosboot --fstype=biosboot --size=1 --ondisk=vda
+part / --fstype ext4 --size=@ROOTSIZE@ --ondisk=vda
+part swap --size=@SWAPSIZE@ --fstype swap --ondisk=vda
+
+# /dev/vdb is partitioned in scripts acording to cluster type
+
+#
+# Repositories
+#
+# This will be parsed for virt-install to download image
+#IMAGE_TREE=http://download.fedoraproject.org/pub/fedora/linux/releases/22/Server/x86_64/os/
+
+repo --name="Fedora" --mirrorlist="http://mirrors.fedoraproject.org/mirrorlist?repo=fedora-22&arch=x86_64"
+repo --name="FedoraUpdates" --mirrorlist="http://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f22&arch=x86_64"
+@REPOURL@
+
+#
+# Packages
+#
+%packages
+@core
+
+ntp
+ntpdate
+
+# This will be modified according to cluster type
+# CLUSTER_PACKAGES
+
+%end
+
+%post
+
+%end

--- a/data/packages_ceph.ks
+++ b/data/packages_ceph.ks
@@ -1,0 +1,4 @@
+# Try to install ceph packages
+
+ceph
+mc

--- a/data/packages_cman.ks
+++ b/data/packages_cman.ks
@@ -1,0 +1,12 @@
+# Try to install cman packages
+
+cman
+dlm
+fence-agents
+resource-agents
+rgmanager
+pacemaker
+lvm2-cluster
+cmirror
+gfs2-utils
+rsyslog

--- a/data/packages_corosync.ks
+++ b/data/packages_corosync.ks
@@ -1,0 +1,17 @@
+# Try to install corosync packages
+
+corosync
+dlm
+fence-agents
+resource-agents
+pacemaker
+lvm2-cluster
+cmirror
+gfs2-utils
+
+# selinux toolchain of policycoreutils, libsemanage, ustr
+#-policycoreutils
+#-checkpolicy
+#-selinux-policy*
+#-libselinux-python
+#-libselinux

--- a/hooks/02_host_install_packages
+++ b/hooks/02_host_install_packages
@@ -6,9 +6,8 @@ echo "Installing required packages on host system"
 
 yum install -y \
 	libvirt libvirt-client qemu-system-x86 \
-	appliance-tools libguestfs-mount \
+	virt-install libguestfs-mount libguestfs-tools libguestfs-tools-c \
 	fence-virtd fence-virtd-multicast fence-virtd-libvirt \
-	openssh-clients ntp \
-	ccs
+	openssh-clients ntp
 
 exit 0

--- a/hooks/06_host_create_guest_kickstart
+++ b/hooks/06_host_create_guest_kickstart
@@ -19,7 +19,9 @@ freespace=$((freespace - qdiskdsize))
 gfs2size=$((freespace / 2))
 freespace=$((freespace - gfs2size))
 clvmdsize=$freespace
-. /etc/sysconfig/clock
+
+[ -f /etc/sysconfig/clock ] && . /etc/sysconfig/clock
+[ -z "$ZONE" ] && ZONE="America/New_York"
 
 [ -n "$cboxrepourl" ] && repourl="repo --name=\"localrepo\" --baseurl=$cboxrepourl"
 
@@ -32,5 +34,8 @@ cat "$cboxkickstart" | sed \
 	-e 's#@CLVMDSIZE@#'$clvmdsize'#g' \
 	-e "s#@REPOURL@#$repourl#g" \
 	> cbox-guest.ks
+
+# Add specific cluster packages
+sed -i "/\# CLUSTER_PACKAGES/r $cboxdatadir/packages_$cboxclustertype.ks" cbox-guest.ks
 
 exit 0

--- a/hooks/50_guest_create
+++ b/hooks/50_guest_create
@@ -5,12 +5,30 @@ set -e
 echo "Creating main/first VM in $cboxtempdir (this will take time!)"
 
 cd $cboxtempdir
+mkdir -p $cboxclustername-boot
 
-[ "$cboxcache" == "yes" ] && extra_params="--cache=$cboxvmsdir/accache"
+eval $(grep IMAGE_TREE cbox-guest.ks | sed -e 's/#//')
 
-appliance-creator -v --vmem=$cboxvirtram --vcpu=$cboxvirtcpus \
-		  -n $cboxclustername-boot \
-		  -c cbox-guest.ks -d -t "$cboxtempdir" $extra_params
+# Hack +100M for bios partition
+ROOT_DISK_GB=$((($cboxvirtroot + $cboxvirtswap + 100 + 1023) / 1024))
+SHARED_DISK_GB=$((($cboxvirtshare + 1023) / 1024))
+
+virt-install --connect=qemu:///system \
+    --network=bridge:testcluster-br0 \
+    --network=bridge:testcluster-br1 \
+    --initrd-inject=cbox-guest.ks \
+    --extra-args="ks=file:/cbox-guest.ks console=tty0 console=ttyS0,115200" \
+    --name=$cboxclustername-boot \
+    --disk path=$cboxclustername-boot/$cboxclustername-boot-vda.raw,size=$ROOT_DISK_GB \
+    --disk path=$cboxclustername-boot/$cboxclustername-boot-vdb.raw,size=$SHARED_DISK_GB \
+    --ram $cboxvirtram \
+    --vcpus=$cboxvirtcpus \
+    --check-cpu \
+    --accelerate \
+    --hvm \
+    --location=$IMAGE_TREE \
+    --nographics \
+    --noreboot
 
 rm -f $cboxclustername-boot/$cboxclustername-boot.xml
 

--- a/hooks/53_guest_fstab_setup
+++ b/hooks/53_guest_fstab_setup
@@ -11,26 +11,28 @@ echo "Making a backup copy of guest /etc/fstab to /etc/fstab.cbox"
 cp $cboxclustername-mount/etc/fstab \
    $cboxclustername-mount/etc/fstab.cbox
 
-echo "Remove clvmd/qdiskd fake mountpoint, and fix gfs2 fs type"
-echo "(leftover from anaconda partitioning hack)"
+if [ "$cboxclustertype" = "corosync" -o "$cboxclustertype" = "cman" ] ; then
+    echo "Remove clvmd/qdiskd fake mountpoint, and fix gfs2 fs type"
+    echo "(leftover from anaconda partitioning hack)"
 
-sed -i \
-   -e 's%.*vdb.*clvm.*%## &%g' \
-   -e 's%.*vdb.*qdisk.*%## &%g' \
-   -e 's%gfs2.*ext3%gfs2 gfs2%g' \
-   $cboxclustername-mount/etc/fstab
+    sed -i \
+       -e 's%.*vdb.*clvm.*%## &%g' \
+       -e 's%.*vdb.*qdisk.*%## &%g' \
+       -e 's%gfs2.*ext3%gfs2 gfs2%g' \
+       $cboxclustername-mount/etc/fstab
 
-echo "Gather info on shared storage"
-cat $cboxclustername-mount/etc/fstab | grep gfs2 | awk '{print $1}' > gfs2_partition
-cat $cboxclustername-mount/etc/fstab | grep qdiskd | awk '{print $2}' > qdiskd_partition
-cat $cboxclustername-mount/etc/fstab | grep clvmd | awk '{print $2}' > clvmd_partition
+    echo "Gather info on shared storage"
+    cat $cboxclustername-mount/etc/fstab | grep gfs2 | awk '{print $1}' > gfs2_partition
+    cat $cboxclustername-mount/etc/fstab | grep qdiskd | awk '{print $2}' > qdiskd_partition
+    cat $cboxclustername-mount/etc/fstab | grep clvmd | awk '{print $2}' > clvmd_partition
 
-echo "Create clvmd/gfs2 device mount point"
-echo "/dev/$cboxclustername-vg/$cboxclustername-lv /srv/cbox/clvmd gfs2 defaults,noatime 0 0" >> \
+    echo "Create clvmd/gfs2 device mount point"
+    echo "/dev/$cboxclustername-vg/$cboxclustername-lv /srv/cbox/clvmd gfs2 defaults,noatime 0 0" >> \
 	$cboxclustername-mount/etc/fstab
 
-echo "Create debugfs fstab entry"
-echo "debugfs /sys/kernel/debug debugfs defaults 0 0" >> \
-	$cboxclustername-mount/etc/fstab
+    echo "Create debugfs fstab entry"
+    echo "debugfs /sys/kernel/debug debugfs defaults 0 0" >> \
+    	$cboxclustername-mount/etc/fstab
+fi
 
 exit 0

--- a/hooks/53_guest_fstab_setup
+++ b/hooks/53_guest_fstab_setup
@@ -26,9 +26,10 @@ if [ "$cboxclustertype" = "corosync" -o "$cboxclustertype" = "cman" ] ; then
     cat $cboxclustername-mount/etc/fstab | grep qdiskd | awk '{print $2}' > qdiskd_partition
     cat $cboxclustername-mount/etc/fstab | grep clvmd | awk '{print $2}' > clvmd_partition
 
-    echo "Create clvmd/gfs2 device mount point"
-    echo "/dev/$cboxclustername-vg/$cboxclustername-lv /srv/cbox/clvmd gfs2 defaults,noatime 0 0" >> \
-	$cboxclustername-mount/etc/fstab
+# FIXME need to fix start of clvmd
+#    echo "Create clvmd/gfs2 device mount point"
+#    echo "/dev/$cboxclustername-vg/$cboxclustername-lv /srv/cbox/clvmd gfs2 defaults,noatime 0 0" >> \
+#	$cboxclustername-mount/etc/fstab
 
     echo "Create debugfs fstab entry"
     echo "debugfs /sys/kernel/debug debugfs defaults 0 0" >> \

--- a/hooks/58_guest_apply_hacks_prerun
+++ b/hooks/58_guest_apply_hacks_prerun
@@ -9,6 +9,9 @@ cd $cboxtempdir
 chroot $cboxclustername-mount su -c "chkconfig iptables off" && true
 chroot $cboxclustername-mount su -c "chkconfig ip6tables off" && true
 
+# FIXME
+chroot $cboxclustername-mount su -c "chkconfig ipmievd off" && true
+
 # DLM config, no fencing
 echo "DLM_CONTROLD_OPTS=-f 0" >$cboxclustername-mount/etc/sysconfig/dlm
 

--- a/hooks/60_guest_create_first_node
+++ b/hooks/60_guest_create_first_node
@@ -17,28 +17,6 @@ if [ -f $SHAREDIMG_ORIG ] ; then
 	mv $SHAREDIMG_ORIG $SHAREDIMG
 else
 	dd if=/dev/zero of=$SHAREDIMG bs=1M count=0 seek=$cboxvirtshare
-
-	# FIXME: copy from kickstart
-	# priciple of ops:
-	# disk size - 64MB for qdisk
-	# free space / 2 (one for gfs2 and one for clvmd)
-
-	freespace=$cboxvirtshare
-	qdiskdsize=64
-	freespace=$((freespace - qdiskdsize))
-	gfs2size=$((freespace / 2))
-	freespace=$((freespace - gfs2size))
-	clvmdsize=$freespace
-
-	parted -s $SHAREDIMG \
-		mklabel gpt \
-		mkpart primary 0 $qdiskdsize \
-		mkpart primary $qdiskdsize $(($qdiskdsize + $gfs2size)) \
-		mkpart primary $(($qdiskdsize + $gfs2size)) $(($qdiskdsize + $gfs2size + $clvmdsize))
-
-	echo "/dev/vdb1" >$cboxtempdir/qdiskd_partition
-	echo "/dev/vdb2" >$cboxtempdir/gfs2_partition
-	echo "/dev/vdb3" >$cboxtempdir/clvmd_partition
 fi
 
 echo "Generating $cboxclustername-node1 libvirt xml template"
@@ -62,5 +40,7 @@ cat $cboxdatadir/libvirt_template.xml | sed \
 echo "Defining $cboxclustername-node1 in libvirt"
 
 virsh define $cboxclustername-node1.xml
+
+virsh undefine $cboxclustername-boot
 
 exit 0

--- a/hooks/60_guest_create_first_node
+++ b/hooks/60_guest_create_first_node
@@ -19,6 +19,13 @@ else
 	dd if=/dev/zero of=$SHAREDIMG bs=1M count=0 seek=$cboxvirtshare
 fi
 
+# Ceph uses per-node disk, not shared storage
+if [ "$cboxclustertype" = "ceph" ] ; then
+	CEPHDISK=$cboxclustername-node1-shareddisk.raw
+	mv $SHAREDIMG $CEPHDISK
+	SHAREDIMG=$CEPHDISK
+fi
+
 echo "Generating $cboxclustername-node1 libvirt xml template"
 
 memory=$((cboxvirtram * 1024))

--- a/hooks/60_guest_create_shared_disk
+++ b/hooks/60_guest_create_shared_disk
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+
+cd $cboxvmsdir/$cboxclustername
+
+echo "Creating shared disk partitions"
+
+SHAREDIMG=$cboxclustername-shareddisk.raw
+
+if [ "$cboxclustertype" = "corosync" -o "$cboxclustertype" = "cman" ] ; then
+
+	# priciple of ops:
+	# disk size - 64MB for qdisk
+	# free space / 2 (one for gfs2 and one for clvmd)
+
+	freespace=$cboxvirtshare
+	qdiskdsize=64
+	freespace=$((freespace - qdiskdsize))
+	gfs2size=$((freespace / 2))
+	freespace=$((freespace - gfs2size))
+	clvmdsize=$freespace
+
+	parted -s $SHAREDIMG \
+		mklabel gpt \
+		mkpart primary 0 $qdiskdsize \
+		mkpart primary $qdiskdsize $(($qdiskdsize + $gfs2size)) \
+		mkpart primary $(($qdiskdsize + $gfs2size)) $(($qdiskdsize + $gfs2size + $clvmdsize))
+
+	echo "/dev/vdb1" >$cboxtempdir/qdiskd_partition
+	echo "/dev/vdb2" >$cboxtempdir/gfs2_partition
+	echo "/dev/vdb3" >$cboxtempdir/clvmd_partition
+elif [ "$cboxclustertype" = "ceph"] ; then
+    # TODO create OSD here
+    echo
+fi
+
+exit 0

--- a/hooks/62_guest_setup_clvmd
+++ b/hooks/62_guest_setup_clvmd
@@ -2,6 +2,8 @@
 
 set -e
 
+[ "$cboxclustertype" != "corosync" -a "$cboxclustertype" != "cman" ] && exit 0
+
 echo "Configure clvmd in the guest $cboxclustername-node1"
 
 cd $cboxtempdir

--- a/hooks/62_guest_setup_clvmd
+++ b/hooks/62_guest_setup_clvmd
@@ -41,7 +41,7 @@ echo "Switching VG $cboxclustername-vg to clustered"
 ssh $cboxclustername-node1 \
 	-i /root/.ssh/id_rsa_$cboxclustername \
 	-o StrictHostKeyChecking=no \
-	"vgchange --clustered y $cboxclustername-vg"
+	"vgchange -y --clustered y $cboxclustername-vg"
 
 echo "Enable lvm cluster locking"
 

--- a/hooks/63_guest_setup_gfs2
+++ b/hooks/63_guest_setup_gfs2
@@ -2,6 +2,8 @@
 
 set -e
 
+[ "$cboxclustertype" != "corosync" -a "$cboxclustertype" != "cman" ] && exit 0
+
 cd $cboxtempdir
 
 echo "Creating gfs2 filesystem on $(cat gfs2_partition)"

--- a/hooks/64_guest_setup_qdiskd
+++ b/hooks/64_guest_setup_qdiskd
@@ -2,6 +2,8 @@
 
 set -e
 
+[ "$cboxclustertype" != "corosync" -a "$cboxclustertype" != "cman" ] && exit 0
+
 cd $cboxtempdir
 
 echo "Creating qdiskd filesystem on $(cat qdiskd_partition)"

--- a/hooks/67_guest_enable_daemons
+++ b/hooks/67_guest_enable_daemons
@@ -15,12 +15,13 @@ enable_daemon() {
 
 daemons=""
 
-[ "$cboxclustertype" = "cman" ] && \
-	daemons="$daemons clvmd cman cmirrord gfs2 modclusterd ricci"
-        try_daemons="gfs2-cluster"
-
-[ "$cboxclustertype" = "corosync" ] && \
-	daemons="$daemons corosync dlm clvmd cmirrord"
+if [ "$cboxclustertype" = "cman" ] ; then
+    daemons="$daemons clvmd cman cmirrord gfs2 modclusterd ricci"
+    try_daemons="gfs2-cluster"
+elif [ "$cboxclustertype" = "corosync" ] ; then
+    daemons="$daemons corosync dlm"
+    try_daemons="clvmd cmirrord"
+fi
 
 [ "$cboxrasmngr" != "none" ] && daemons="$daemons $cboxrasmngr"
 
@@ -28,7 +29,7 @@ for i in $daemons ntpd ntpdate; do
 	enable_daemon $i
 done
 
-for i in $try_daemons; do
+for i in "$try_daemons"; do
 	enable_daemon $i || echo "WARNING: Daemon $i failed."
 done
 

--- a/hooks/70_guest_clone_nodes
+++ b/hooks/70_guest_clone_nodes
@@ -12,6 +12,12 @@ for i in $(seq 2 $cboxnumnodes); do
 	echo "Creating $cboxclustername-node$i boot disk"
 	cp $cboxclustername-node1.raw $cboxclustername-node$i.raw
 
+	if [ "$cboxclustertype" = "ceph" ] ; then
+	    SHAREDIMG=$cboxclustername-node$i-shareddisk.raw
+	    cp $cboxclustername-node1-shareddisk.raw $SHAREDIMG
+	else
+	    SHAREDIMG=$cboxclustername-shareddisk.raw
+	fi
 
 	echo "Creating $cboxclustername-node$i libvirt xml template"
 	cat $cboxdatadir/libvirt_template.xml | sed \
@@ -20,7 +26,7 @@ for i in $(seq 2 $cboxnumnodes); do
 		-e 's#@MEMORY@#'$memory'#g' \
 		-e 's#@VCPUS@#'$cboxvirtcpus'#g' \
 		-e 's#@DISK@#'$cboxvmsdir/$cboxclustername/$cboxclustername-node$i.raw'#g' \
-		-e 's#@SHAREDDISK@#'$cboxvmsdir/$cboxclustername/$cboxclustername-shareddisk.raw'#g' \
+		-e 's#@SHAREDDISK@#'$cboxvmsdir/$cboxclustername/$SHAREDIMG'#g' \
 		-e 's#@MACADDRESS0@#54:52:00:00:00:'$(printf '%x' $i)'#g' \
 		-e 's#@BRIDGE0@#'$cboxclustername-br0'#g' \
 		-e 's#@MACADDRESS1@#54:52:00:00:01:'$(printf '%x' $i)'#g' \

--- a/hooks/Makefile.am
+++ b/hooks/Makefile.am
@@ -18,6 +18,7 @@ HOOKS			= 01_host_update \
 			  58_guest_apply_hacks_prerun \
 			  59_guest_umount \
 			  60_guest_create_first_node \
+			  60_guest_create_shared_disk \
 			  61_guest_start_first \
 			  61_guest_create_driver_node \
 			  62_guest_setup_clvmd \


### PR DESCRIPTION
Tried to reuse cbox for ceph...
- used virt-install (oz-install is too simpole, cannot create multiple eth a disks)
- kickstart need some hacks (to maintain it in one place, including --location for virt-install)

Only Fedora21 should work for now.
Corosync type probably still does not configure itself properly....

Anyway, if it is useful, please consider merging this.
